### PR TITLE
protect user from navigating away while clicking links in About

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -1909,6 +1909,7 @@ var CGUI = function()
 
     o = document.createElement("a");
     o.href = "help.html";
+    o.target = '_blank';
     o.appendChild(document.createTextNode("Help"));
     parent.appendChild(o);
     parent.appendChild(document.createElement("br"));

--- a/gui.js
+++ b/gui.js
@@ -1898,8 +1898,8 @@ var CGUI = function()
     parent.appendChild(o);
 
     o = document.createElement("p");
-    o.innerHTML = "Licensed under the <a href=\"gpl.txt\">GPL v3</a> license " +
-                  "(get the <a href=\"https://github.com/mbitsnbites/soundbox\">source</a>).";
+    o.innerHTML = "Licensed under the <a href=\"gpl.txt\" target=\"_blank\" rel=\"noopener noreferrer\">GPL v3</a> license " +
+                  "(get the <a href=\"https://github.com/mbitsnbites/soundbox\" target=\"_blank\" rel=\"noopener noreferrer\">source</a>).";
     o.style.fontStyle = "italic";
     parent.appendChild(o);
 


### PR DESCRIPTION
@mbitsnbites check this out

added target=_blank" and rel=noopener/noreferrer to make sure that GPL v3 licence and source links open in another tab instead of soundbox-tab.
*edit* also added o.target = '_blank'; to make help.html not kick user away.

