### PR TITLE
If there is changes, asks user to confirm "load", "new" and leaving page 

### DIFF
--- a/common.js
+++ b/common.js
@@ -31,3 +31,56 @@ function include(filename)
 	head.appendChild(s);
 }
 
+// based on https://j11y.io/javascript/deep-copying-of-objects-and-arrays/
+function deepCopy(obj)
+{
+  if (Object.prototype.toString.call(obj) === '[object Array]') {
+    var out = [], i = 0, len = obj.length;
+    for ( ; i < len; i++ ) {
+      out[i] = arguments.callee(obj[i]);
+    }
+    return out;
+  }
+  if (typeof obj === 'object') {
+    var out = {}, i;
+    for ( i in obj ) {
+      out[i] = arguments.callee(obj[i]);
+    }
+    return out;
+  }
+  return obj;
+}
+
+
+function deepEquals(a,b)
+{   
+  // if a and b are arrays, compare them as such
+  if (Object.prototype.toString.call(a) === '[object Array]' && 
+      Object.prototype.toString.call(b) === '[object Array]') {
+    if (a.length != b.length)
+      return false;
+    for (var i=0;i < a.length; i++ ) {
+      if (!arguments.callee(a[i],b[i]))
+        return false;
+    }
+    return true;
+  }
+  // if a and b are associative arrays, compare them as such
+  if (typeof a === 'object' && typeof b === 'object') {   
+    var checkKeys = function(a,b) {
+      for(key in a) //In a and not in b
+        if(!(key in b))
+          return false;
+      return true;
+    }
+    if (!checkKeys(a,b) || !checkKeys(b,a))
+      return false;
+    for (i in a) {
+      if (!arguments.callee(a[i],b[i]))
+        return false;
+    }
+    return true;
+  }   
+  return a === b;
+}
+


### PR DESCRIPTION
Stores a deep copy of the song when it is created/loaded/last saved. When the user tries to create a new song, load or leave the page, does a deep comparison between the current song and the song before modifications. If they are not the same, asks the user to confirm before overwriting the song.

For the record, I first tried the solution to track when the song has changed. It proved quite bug-prone, as the song is changed in so many places, and setting the flag was littered throughout the code... I finally settled for this solution.

deepCompare and deepCopy are helper functions that could be replaced with more modern stuff e.g. many general purpose libraries and ES6 come with them, if it feels too ugly to have them in the gui.js.