### PR TITLE
make keyboard image not draggable + use css to disable all dragging

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
 <div class="octaveSelector">
 Octave: <span id="keyboardOctave" title="Octave">5</span>
 </div>
-<img id="octaveDown" title="Octave down (<)" alt="&lt;" src="gui/button-prev.png" width="23" height="20" />&nbsp;<img id="keyboard" src="gui/keyboard.jpg" width="421" height="112" alt="Keyboard" />&nbsp;<img id="octaveUp" title="Octave up (>)" alt="&gt;" src="gui/button-next.png" width="23" height="20" />
+<img id="octaveDown" title="Octave down (<)" alt="&lt;" src="gui/button-prev.png" width="23" height="20" />&nbsp;<img draggable="false" id="keyboard" src="gui/keyboard.jpg" width="421" height="112" alt="Keyboard" />&nbsp;<img id="octaveUp" title="Octave up (>)" alt="&gt;" src="gui/button-next.png" width="23" height="20" />
 </div>
 
 </td>

--- a/screen.css
+++ b/screen.css
@@ -25,6 +25,16 @@ body {
   margin: 0;
 }
 
+img {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-user-drag: none;
+  user-drag: none;
+  -webkit-touch-callout: none;
+}
+
 #content {
   position: relative;
   width: 1210px;


### PR DESCRIPTION
added draggable="false" to img id keyboard.
and 

img {
  -moz-user-select: none;
  -webkit-user-select: none;
  -ms-user-select: none;
  user-select: none;
  -webkit-user-drag: none;
  user-drag: none;
  -webkit-touch-callout: none;
}

to screen.css to make all images un-draggable.