### PR TITLE
Refactoring GUI logic

### DIFF
--- a/help.html
+++ b/help.html
@@ -96,12 +96,16 @@ editor (4).</p>
 <img class="smallButton" src="gui/plus-one.png" alt="+1" />/<img class="smallButton" src="gui/minus-one.png" alt="-1" />
 buttons below the sequencer), the corresponding note pattern will be visible and
 editable in the pattern editor (3). Holding shift while typing the character will 
-also advance the cursor to the next row.</p>
+also advance the cursor to the next row. The cells can be navigated using the
+arrow keys. Holding control down while navigating the table moves to the very
+end (e.g. the top-most cell when pressing arrow up).</p>
 
 <p>It is possible to select a range in the sequencer (by click+dragging), and
 then copy the selected range with the <img class="smallButton" src="gui/edit-copy.png" alt="Copy" /> button,
 and the copied range can then be pasted to any other position with the
-<img class="smallButton" src="gui/edit-paste.png" alt="Paste" /> button.</p>
+<img class="smallButton" src="gui/edit-paste.png" alt="Paste" /> button.
+A range can also be selected by holding shift down and navigating the table
+with arrows. Alt-shift and arrows adjust the second corner of the selection range.</p>
 
 <p>Hitting enter with a range selected fills the empty space in that range 
 by looping or interpolating the values at the top of the range. For example:
@@ -124,8 +128,8 @@ used to dynamically control all aspects of an instrument during playback.</p>
 selected in the sequencer</em>. Notes are entered with the piano (5), the keyboard
 or a MIDI input device (see below).</p>
 
-<p>Just as with the sequencer, it is possible to copy and paste note data with
-the <img class="smallButton" src="gui/edit-copy.png" alt="Copy" /> &amp;
+<p>Just as with the sequencer, it is possible to select a range and copy and 
+paste note data with the <img class="smallButton" src="gui/edit-copy.png" alt="Copy" /> &amp;
 <img class="smallButton" src="gui/edit-paste.png" alt="Paste" /> buttons.
 It is also possible to transpose a selected range of notes with the
 <img class="smallButton" src="gui/plus-one.png" alt="+1" />,

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ function include(filename) {
 include("common.js");
 include("gui.js");
 </script>
-  <link rel="stylesheet" type="text/css" href="screen.css?version=2" />
+  <link rel="stylesheet" type="text/css" href="screen.css?version=3" />
   <link rel="shortcut icon" href="favicon.ico" />
 </head>
 <body onload="gui_init()">

--- a/screen.css
+++ b/screen.css
@@ -203,9 +203,14 @@ table.tracks td:hover, table.tracks tr.beat td:hover {
   background: #77d;
 }
 
-table.tracks td.selected, table.tracks tr.beat td.selected {
+table.tracks td.cursor, table.tracks tr.beat td.cursor {
   color: #fff;
   background: #88f;
+}
+
+table.tracks td.selected, table.tracks tr.beat td.selected {
+  color: #fff;
+  background: #66c;
 }
 
 #sequencer table.tracks td {


### PR DESCRIPTION
This is a large refactoring to have better code reuse between the three tables, sequencer, pattern and fxtrack. All three are instances of class CTableEditor, which tracks the currently selected cell and selection range. The instances are called mSeq, mPattern and mFxTrack.

Despite no apparent loss in functionality and using 300 lines less, this PR also solves several issues: #19, #50, and #51.

Internally, CTableEditor tracks the selected cells. It also provices automatically copy/paste functionality. And some general methods to help adjusting the contents of the selection (e.g. methods used in +1/-1 buttons). Also, it has a "suppressUpdate" and "resumeUpdate" methods, which can be used to avoid flooding update calls if you know you are going to change several cells. The update will get called only after the last resumeUpdate has been called.

There still isn't observer-pattern to have changes in underlying data automatically reflected to the GUI; rather, the CTableEditor is just slightly better encapsulated version of the old logic: changing the data through CTableEditor guarantees that updates are called appropriately. I wasn't brave enough to start touching the instrument side of things, yet, but I thought it would be better to perfect the CTableEditor change. CInstrumentEditor will be quite a different beast.