### PR TITLE
an HTML5 -> a HTML5

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -2036,7 +2036,7 @@ var CGUI = function()
     parent.appendChild(o);
 
     o = document.createElement("p");
-    o.appendChild(document.createTextNode("an HTML5 synth music tracker"));
+    o.appendChild(document.createTextNode("a HTML5 synth music tracker"));
     parent.appendChild(o);
 
     o = document.createElement("p");


### PR DESCRIPTION
Replacing `an` with `a` for grammar's sake