### PR TITLE
Fix jammer working in Chrome again.

### DIFF
--- a/jammer.js
+++ b/jammer.js
@@ -333,6 +333,17 @@ var CJammer = function () {
         return;
       }
     }
+    
+    // Fix for Chrome: Chrome requires AudioContext to be resumed only after
+    // user gestures on the screen.
+    if (typeof mAudioContext != "undefined") {
+      var resumeAudio = function() {
+        if (typeof mAudioContext == "undefined" || mAudioContext == null) return;
+        if (mAudioContext.state == "suspended") mAudioContext.resume();
+        document.removeEventListener("click", resumeAudio);
+      }
+      document.addEventListener("click", resumeAudio);
+    }
 
     // Get actual sample rate (SoundBox is hard-coded to 44100 samples/s).
     mSampleRate = mAudioContext.sampleRate;


### PR DESCRIPTION
Chrome nowadays prevents AudioContext from starting before any user gesture. Solution is to wait for a click and only then resume the audio.

See for example: https://forum.yoyogames.com/index.php?threads/audio-doesnt-work-anymore-in-chrome-the-audiocontext-was-not-allowed-to-start.46987/