### PR TITLE
player-small: Added createAudioBuffer()

### DIFF
--- a/player-small.js
+++ b/player-small.js
@@ -302,6 +302,18 @@ var CPlayer = function() {
         return mCurrentCol / mSong.numChannels;
     };
 
+    // Create a AudioBuffer from the generated audio data
+    this.createAudioBuffer = function(context) {
+        var buffer = context.createBuffer(2, mMixBuf.length / 2, 44100);
+        for (var i = 0; i < 2; i ++) {
+            var data = buffer.getChannelData(i);
+            for (var j = 0, k = i; j < buffer.length; j ++, k += 2) {
+                data[j] = mMixBuf[k] / 65536;
+            }
+        }
+        return buffer;
+    };
+    
     // Create a WAVE formatted Uint8Array from the generated audio data
     this.createWave = function() {
         // Create WAVE header

--- a/player-small.js
+++ b/player-small.js
@@ -304,11 +304,11 @@ var CPlayer = function() {
 
     // Create a AudioBuffer from the generated audio data
     this.createAudioBuffer = function(context) {
-        var buffer = context.createBuffer(2, mMixBuf.length / 2, 44100);
+        var buffer = context.createBuffer(2, mNumWords / 2, 44100);
         for (var i = 0; i < 2; i ++) {
             var data = buffer.getChannelData(i);
-            for (var j = 0, k = i; j < buffer.length; j ++, k += 2) {
-                data[j] = mMixBuf[k] / 65536;
+            for (var j = i; j < mNumWords; j += 2) {
+                data[j >> 1] = mMixBuf[j] / 65536;
             }
         }
         return buffer;


### PR DESCRIPTION
These days the WebAudio API has pretty good browser support.

Instead of creating a WAVE and use `<audio>` elements, we can instead generate a `AudioBuffer` ready to be used with the WebAudio API.