### PR TITLE
gui.js: fixed scrollIntoView() usage

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -370,14 +370,14 @@ var CTableEditor = function() {
     mCol1 = col;
     mRow1 = row;
     self.update();
-    self.scrollIntoView(col,row);
+    self.scrollIntoView(row);
   }
 
   this.setSelectionCorner2 = function(col,row) {
     mCol2 = col;
     mRow2 = row;
     self.update();
-    self.scrollIntoView(col,row);
+    self.scrollIntoView(row);
   }
 
   this.copy = function() {


### PR DESCRIPTION
There are a couple of calls to `scrollIntoView()` with incorrect parameters that makes it difficult to work with long songs.

Before:

https://user-images.githubusercontent.com/97088/115021453-e13ae500-9eb3-11eb-94c6-b5209fb64428.mov

After:

https://user-images.githubusercontent.com/97088/115021481-eb5ce380-9eb3-11eb-81c3-3008fd57cad8.mov

